### PR TITLE
Fix DESCRIPTION file to allow installation.

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -5,7 +5,7 @@ Title: Cache calls to the web
 Description: Cache calls to the web
 License: CC0
 Authors@R: c(person("Scott", "Chamberlain", role = c("aut", "cre"), email =
-    "myrmecocystus@gmail.com"), person("Carl", "Boettiger", role = c("auth"), 
+    "myrmecocystus@gmail.com"), person("Carl", "Boettiger", role = c("aut"), 
     email = "cboettig@gmail.com"), person("Karthik", "Ram", role =
     "aut"), person("Edmund", "Hart", role="aut"))
 LazyLoad: yes

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -5,7 +5,7 @@ Title: Cache calls to the web
 Description: Cache calls to the web
 License: CC0
 Authors@R: c(person("Scott", "Chamberlain", role = c("aut", "cre"), email =
-    "myrmecocystus@gmail.com"), person("Carl", "Boettiger", role = c("auth), 
+    "myrmecocystus@gmail.com"), person("Carl", "Boettiger", role = c("auth"), 
     email = "cboettig@gmail.com"), person("Karthik", "Ram", role =
     "aut"), person("Edmund", "Hart", role="aut"))
 LazyLoad: yes

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -5,8 +5,8 @@ Title: Cache calls to the web
 Description: Cache calls to the web
 License: CC0
 Authors@R: c(person("Scott", "Chamberlain", role = c("aut", "cre"), email =
-    "myrmecocystus@gmail.com"), person("Carl", "Boettiger", role = c("aut",
-    "cre"), email = "cboettig@gmail.com"), person("Karthik", "Ram", role =
+    "myrmecocystus@gmail.com"), person("Carl", "Boettiger", role = c("auth), 
+    email = "cboettig@gmail.com"), person("Karthik", "Ram", role =
     "aut"), person("Edmund", "Hart", role="aut"))
 LazyLoad: yes
 LazyData: yes


### PR DESCRIPTION
R requires that no more than one author have the 'cre' attribute in the DESCRIPTION file.  This prevents installation.  This patch fixes #6.